### PR TITLE
0.5.3 - Tweak dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Flutter application for viewing a rich feed of GitHub activity.
 
 ## Project status:
 
-**Public Preview**: Version 0.5.2
+**Public Preview**: Version 0.5.3
 
 **Supported platforms**: Android, iOS (see notes)
 

--- a/lib/widgets/dialogs/logout_dialog.dart
+++ b/lib/widgets/dialogs/logout_dialog.dart
@@ -13,20 +13,19 @@ class LogOutDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      content: Text(
-        'Would you like to log out?',
+      title: Text(
+        'Log Out',
         style: TextStyle(
           color: context.colorScheme.onBackground,
         ),
       ),
       actions: [
-        FlatButton(
-          textColor: context.colorScheme.onBackground,
+        TextButton(
           child: Text('Cancel'),
           onPressed: () => Navigator.pop(context),
         ),
-        FlatButton(
-          child: Text('Yes'),
+        TextButton(
+          child: Text('Log Out'),
           onPressed: () => githubService.logOut(),
         ),
       ],

--- a/lib/widgets/dialogs/theme_switcher_dialog.dart
+++ b/lib/widgets/dialogs/theme_switcher_dialog.dart
@@ -34,7 +34,7 @@ class _ThemeSwitcherDialogState extends State<ThemeSwitcherDialog> {
           value: ThemeMode.system,
           selected: widget.themeMode.isSystemMode,
           groupValue: widget.themeMode,
-          activeColor: Theme.of(context).accentColor,
+          activeColor: Theme.of(context).primaryColor,
           onChanged: (themeMode) {
             prefsbloc.setThemeModePref(themeMode);
             setState(() {});
@@ -46,7 +46,7 @@ class _ThemeSwitcherDialogState extends State<ThemeSwitcherDialog> {
           value: ThemeMode.light,
           selected: widget.themeMode.isLightMode,
           groupValue: widget.themeMode,
-          activeColor: Theme.of(context).accentColor,
+          activeColor: Theme.of(context).primaryColor,
           onChanged: (themeMode) {
             prefsbloc.setThemeModePref(themeMode);
             setState(() {});
@@ -58,7 +58,7 @@ class _ThemeSwitcherDialogState extends State<ThemeSwitcherDialog> {
           value: ThemeMode.dark,
           selected: widget.themeMode.isDarkMode,
           groupValue: widget.themeMode,
-          activeColor: Theme.of(context).accentColor,
+          activeColor: Theme.of(context).primaryColor,
           onChanged: (themeMode) {
             prefsbloc.setThemeModePref(themeMode);
             setState(() {});

--- a/lib/widgets/menu_sheet_content.dart
+++ b/lib/widgets/menu_sheet_content.dart
@@ -61,7 +61,7 @@ class _MenuSheetContentState extends State<MenuSheetContent>
                 ),
               ),
               child: Text(
-                'Log out',
+                'Log Out',
                 style: TextStyle(
                   color: context.isDarkTheme ? Colors.white : Colors.black,
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: github_activity_feed
 description: A Flutter application for viewing a rich feed of GitHub activity.
 publish_to: 'none'
 
-version: 0.5.2
+version: 0.5.3
 
 environment:
   sdk: '>=2.7.0 <3.0.0'


### PR DESCRIPTION
* `LogOutDialog` now uses `title` instead of content, has updated text, and uses new Material buttons
* `ThemeSwitcherDialog` now uses `primaryColor` instead of `accentColor`
* Update 'log out' button text
* Update version